### PR TITLE
Better support building passenger with RVM and chef-rvm

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,3 +11,4 @@ default['passenger']['package']['name'] = nil
 default['passenger']['package']['version'] = nil
 default['passenger']['ruby_bin'] = languages['ruby']['ruby_bin']
 default['passenger']['install_module'] = true
+default['passenger']['rvm_ruby_string'] = 'default'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,6 +12,8 @@ recipe "passenger_apache2::mod_rails", "Enables Apache module configuration for 
 depends "apache2", ">= 1.0.4"
 depends "build-essential"
 
+suggests "chef-rvm"
+
 %w{ redhat centos scientific amazon oracle ubuntu debian arch }.each do |os|
   supports os
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,6 +27,8 @@ include_recipe 'apache2'
 case node['passenger']['install_method']
 when 'source'
   include_recipe 'passenger_apache2::source'
+when 'source_rvm'
+  include_recipe 'passenger_apache2::source_rvm'
 when 'package'
   include_recipe 'passenger_apache2::package'
   node.set['passenger']['manage_module_conf'] = false

--- a/recipes/source_dependencies.rb
+++ b/recipes/source_dependencies.rb
@@ -1,0 +1,44 @@
+#
+# Cookbook Name:: passenger_apache2
+# Recipe:: source_dependencies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_recipe 'build-essential'
+
+node.default['passenger']['apache_mpm']  = 'prefork'
+
+case node['platform_family']
+when 'arch'
+  package 'apache'
+when 'rhel'
+  package 'httpd-devel'
+  if node['platform_version'].to_f < 6.0
+    package 'curl-devel'
+  else
+    package 'libcurl-devel'
+    package 'openssl-devel'
+    package 'zlib-devel'
+  end
+else
+  apache_development_package =  if %w( worker threaded ).include? node['passenger']['apache_mpm']
+                                  'apache2-threaded-dev'
+                                else
+                                  'apache2-prefork-dev'
+                                end
+  %W( #{apache_development_package} libapr1-dev libcurl4-gnutls-dev ).each do |pkg|
+    package pkg do
+      action :upgrade
+    end
+  end
+end

--- a/recipes/source_rvm.rb
+++ b/recipes/source_rvm.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: passenger_apache2
-# Recipe:: source
+# Recipe:: source_rvm
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@
 
 include_recipe 'passenger_apache2::source_dependencies'
 
-gem_package 'passenger' do
+rvm_gem 'passenger' do
+  ruby_string node['passenger']['rvm_ruby_string']
   version node['passenger']['version']
 end
 
-execute 'passenger_module' do
-  command "#{node['passenger']['ruby_bin']} #{node['passenger']['root_path']}/bin/passenger-install-apache2-module _#{node['passenger']['version']}_ --auto"
+rvm_shell 'passenger_module' do
+  code "passenger-install-apache2-module _#{node['passenger']['version']}_ --auto"
   creates node['passenger']['module_path']
   only_if { node['passenger']['install_module'] }
+  ruby_string node['passenger']['rvm_ruby_string']
 end


### PR DESCRIPTION
I don't think this pull request is in its final form, but I was hoping it might serve as a jumping off point for getting some feedback as to what you'd like to see in terms of better integrating this cookbook with chef-rvm.

Clearly not an issue with this cookbook, but better integration would make situations like https://github.com/fnichol/chef-rvm/issues/249 easier to handle. This is very RVM specific so rbenv would still suffer from the same problem, so ideas on handling both in a more generic way are welcome.

I'm fairly certain I'm up to date on my Opscode contributor paperwork.
