### PR TITLE
Remove pessimistic version constraint on apache2

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ version           '2.2.3'
 recipe 'passenger_apache2', 'Installs Passenger as an Apache module'
 recipe 'passenger_apache2::mod_rails', 'Enables Apache module configuration for passenger module'
 
-depends 'apache2', '~> 1.0'
+depends 'apache2'
 depends 'build-essential'
 
 %w{ redhat centos scientific amazon oracle ubuntu debian arch }.each do |os|


### PR DESCRIPTION
I believe as of apache2's 3.0 release, the issue that caused the pre 2.x version constraint is resolved. I have tested this on a fresh image of Ubuntu 14.04 with apache2 3.0.1 and this change, using the mod_rails recipe.