### PR TITLE
Notify apache to reload if any of the apache configurations change

### DIFF
--- a/recipes/mod_rails.rb
+++ b/recipes/mod_rails.rb
@@ -31,6 +31,8 @@ template "#{node['apache']['dir']}/mods-available/passenger.load" do
   group 'root'
   mode '0644'
   only_if { platform_family?('debian') }
+
+  notifies :reload, 'service[apache2]'
 end
 
 # Allows proper default path if root path was overridden
@@ -42,6 +44,8 @@ template "#{node['apache']['dir']}/mods-available/passenger.conf" do
   owner 'root'
   group 'root'
   mode '0644'
+
+  notifies :reload, 'service[apache2]'
 end
 
 apache_module 'passenger' do


### PR DESCRIPTION
For a fresh install, the call to the apache_module will cause the service to be reloaded since it creates a new symlink into the mods-enabled directory.  However, if I upgrade the passenger version on a node, the passenger.load and passenger.conf files are updated but nothing causes the apache2 service to be reloaded in that case.  

This just adds some additional delayed notifications to the apache2 service to ensure apache is reloaded whenever any of the relevant configuration files are modified.