### PR TITLE
use the correct gem binary

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,6 +2,8 @@ default['passenger']['install_method'] = 'source'
 
 default['passenger']['version']     = '4.0.53'
 default['passenger']['apache_mpm']  = nil
+default['passenger']['bin_dir'] = nil
+default['passenger']['bin'] = "#{languages['ruby']['bin_dir']}"
 default['passenger']['root_path']   = "#{languages['ruby']['gems_dir']}/gems/passenger-#{passenger['version']}"
 default['passenger']['module_path'] = "#{passenger['root_path']}/#{Chef::Recipe::PassengerConfig.build_directory_for_version(passenger['version'])}/apache2/mod_passenger.so"
 default['passenger']['max_pool_size'] = 6

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,6 @@ default['passenger']['install_method'] = 'source'
 default['passenger']['version']     = '4.0.53'
 default['passenger']['apache_mpm']  = nil
 default['passenger']['bin_dir'] = nil
-default['passenger']['bin'] = "#{languages['ruby']['bin_dir']}"
 default['passenger']['root_path']   = "#{languages['ruby']['gems_dir']}/gems/passenger-#{passenger['version']}"
 default['passenger']['module_path'] = "#{passenger['root_path']}/#{Chef::Recipe::PassengerConfig.build_directory_for_version(passenger['version'])}/apache2/mod_passenger.so"
 default['passenger']['max_pool_size'] = 6

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -45,6 +45,7 @@ end
 
 gem_package "passenger" do
   version node['passenger']['version']
+  gem_binary "#{node['passenger']['bin_dir']}/gem" unless node['passenger']['bin_dir'].nil?
 end
 
 execute "passenger_module" do


### PR DESCRIPTION
so when using chef-solo, ohai will ALWAYS have node.languages.ruby pointed at embedded-chef-ruby, and gem_package will function the same as chef_gem, and stick gems in the wrong place.  this lets you [optionally] override the gem_binary used for install