### PR TITLE
Update Passenger version and templates

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 default['passenger']['install_method'] = 'source'
 
-default['passenger']['version']     = '4.0.53'
+default['passenger']['version']     = '5.0.18'
 default['passenger']['apache_mpm']  = nil
 default['passenger']['root_path']   = "#{languages['ruby']['gems_dir']}/gems/passenger-#{passenger['version']}"
 default['passenger']['module_path'] = "#{passenger['root_path']}/#{Chef::Recipe::PassengerConfig.build_directory_for_version(passenger['version'])}/apache2/mod_passenger.so"

--- a/templates/default/passenger_web_app.conf.erb
+++ b/templates/default/passenger_web_app.conf.erb
@@ -9,8 +9,12 @@
   <Directory <%= @params[:docroot] %>>
     Options FollowSymLinks
     AllowOverride None
+    <% if node['apache']['version'] == '2.4' -%>
+    Require all granted
+    <% else -%>
     Order allow,deny
     Allow from all
+    <% end -%>
   </Directory>
 
   LogLevel info

--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -9,8 +9,12 @@
   <Directory <%= @params[:docroot] %>>
     Options FollowSymLinks
     AllowOverride None
+    <% if node['apache']['version'] == '2.4' -%>
+    Require all granted
+    <% else -%>
     Order allow,deny
     Allow from all
+    <% end -%>
   </Directory>
 
   LogLevel info


### PR DESCRIPTION
    * Bump version to current stable 5.0.18
    * Update example apache templates to match apache cookbook (2.4 support)

