### PR TITLE
Correct documentation - custom web app template

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ end
 
 A sample config template is provided, `web_app.conf.erb`. If this is suitable for your application, add 'cookbook "passenger_apache2"' to the define above to use that template. Otherwise, copy the template to the cookbook where you're using `web_app`, and modify as needed. The cookbook parameter is optional, if omitted it will search the cookbook where the define is used.
 
+Example:
+
+```
+web_app "myproj" do
+...
+  cookbook "passenger_apache2"
+...
+end
+```
+
 ## Known Issues
 
 When run as a daemonized process under init on linux, using <https://github.com/opscode-cookbooks/chef-client/blob/master/recipes/init_service.rb> for example, the /sbin/service script scrubs the environment, including the HOME environment variable. In some versions, Passenger depends on the HOME environment variable to be present. This can be worked around by setting the necessary environment variables directly in your recipes.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ web_app "myproj" do
 end
 ```
 
-A sample config template is provided, `web_app.conf.erb`. If this is suitable for your application, add 'cookbook "passenger"' to the define above to use that template. Otherwise, copy the template to the cookbook where you're using `web_app`, and modify as needed. The cookbook parameter is optional, if omitted it will search the cookbook where the define is used.
+A sample config template is provided, `web_app.conf.erb`. If this is suitable for your application, add 'cookbook "passenger_apache2"' to the define above to use that template. Otherwise, copy the template to the cookbook where you're using `web_app`, and modify as needed. The cookbook parameter is optional, if omitted it will search the cookbook where the define is used.
 
 ## Known Issues
 


### PR DESCRIPTION
### Description

Corrects advice given in the documentation, specifically in the Usage section's paragraph on the the web_app resource's "cookbook" parameter. The current documentation suggests adding 
```cookbook "passenger"```, but this is incorrect, and should be ```cookbook "passenger_apache2"``` instead.

I also added an example of its usage, in case it wasn't immediately clear from the paragraph.